### PR TITLE
image display improvements

### DIFF
--- a/hosting/src/app/pages/articles/article-details/details.component.html
+++ b/hosting/src/app/pages/articles/article-details/details.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="article$ | async as article; else loading">
   <app-page-header [title]="article.title" [date]="article.created" [owner]="article.ownerName"></app-page-header>
   <main>
-    <app-image-card *ngIf="image$ | async as image" [data]="image"></app-image-card>
+    <img [src]="image$ | async">
     <app-markdown-viewer [markdownText]="article.content"></app-markdown-viewer>
     <mat-chip-list>
       <mat-chip *ngFor="let tag of article.tags" (click)="onTagClick(tag)"> {{ tag }} </mat-chip>

--- a/hosting/src/app/pages/articles/article-details/details.component.scss
+++ b/hosting/src/app/pages/articles/article-details/details.component.scss
@@ -2,15 +2,12 @@
 
 main {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
-  grid-template-areas: 'content image' 'tags tags';
-
-  @media screen and (max-width: 600px) {
-    padding: 0 16px;
     grid-template-columns: 1fr;
     grid-template-rows: auto;
     grid-template-areas: 'image' 'content' 'tags';
+
+  @media screen and (max-width: 600px) {
+    padding: 0 16px;
   }
 }
 
@@ -19,8 +16,11 @@ main {
   justify-content: center;
 }
 
-app-image-card {
+img {
   grid-area: image;
+  padding-bottom: 2rem;
+  max-width: 100%;
+  justify-self: center;
 }
 
 app-markdown-viewer {

--- a/hosting/src/app/pages/articles/article-details/details.component.ts
+++ b/hosting/src/app/pages/articles/article-details/details.component.ts
@@ -28,7 +28,7 @@ export class DetailsComponent implements OnDestroy {
       }
     })
   );
-  image$ = this.store.select('article', 'image');
+  image$ = this.store.select('article', 'imageUrl');
   isLoading$ = this.store.select('article', 'isLoading');
   canEdit$ = this.store.select(canEdit);
 

--- a/hosting/src/app/pages/groups/common/common.component.html
+++ b/hosting/src/app/pages/groups/common/common.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="textData$ | async as article; else loading">
   <app-page-header [title]="article.title" [date]="article.created" [owner]="article.ownerName"></app-page-header>
   <main>
-    <app-image-card *ngIf="imageData$ | async as image" [data]="image"></app-image-card>
+    <img [src]="imageUrl$ | async">
     <app-markdown-viewer [markdownText]="article.content"></app-markdown-viewer>
   </main>
   <div class="fab-container">

--- a/hosting/src/app/pages/groups/common/common.component.scss
+++ b/hosting/src/app/pages/groups/common/common.component.scss
@@ -2,14 +2,12 @@
 
 main {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto;
-  grid-template-areas: 'content image';
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas: 'image' 'content' 'tags';
 
   @media screen and (max-width: 600px) {
     padding: 0 16px;
-    grid-template-columns: 1fr;
-    grid-template-areas: 'image' 'content';
   }
 }
 
@@ -18,8 +16,11 @@ main {
   justify-content: center;
 }
 
-app-image-card {
+img {
   grid-area: image;
+  padding-bottom: 2rem;
+  max-width: 100%;
+  justify-self: center;
 }
 
 app-markdown-viewer {

--- a/hosting/src/app/pages/groups/common/common.component.ts
+++ b/hosting/src/app/pages/groups/common/common.component.ts
@@ -13,7 +13,7 @@ import { tap } from 'rxjs/operators';
 })
 export class CommonComponent implements OnDestroy, OnInit {
   textData$ = this.store.select('group', 'article');
-  imageData$ = this.store.select('group', 'image');
+  imageUrl$ = this.store.select('group', 'imageUrl');
   groupName$ = this.store.select('router', 'state', 'data', 'groupName').pipe(
     tap((el) => {
       this.seo.setTags(el, `Gruppen der RöSeNa: ${el}`, undefined, `/groups/${el}`);

--- a/hosting/src/app/pages/images/image-details/details.component.html
+++ b/hosting/src/app/pages/images/image-details/details.component.html
@@ -1,7 +1,11 @@
 <mat-progress-bar [mode]="'indeterminate'" [color]="'accent'" *ngIf="isLoading$ | async"></mat-progress-bar>
 <ng-container *ngIf="image$ | async as image">
   <main>
-    <img [src]="url$ | async" alt="Bild Detailansicht" />
+    <ng-container *ngIf="url$ | async as url">
+    <a [href]="url" target="_blank">
+      <img [src]="url" alt="Bild Detailansicht" />
+    </a>
+    </ng-container>
     <mat-chip-list>
       <mat-chip *ngFor="let tag of image.tags" (click)="onTagClick(tag)">{{ tag }}</mat-chip>
     </mat-chip-list>

--- a/hosting/src/app/pages/images/image-overview/overview.component.ts
+++ b/hosting/src/app/pages/images/image-overview/overview.component.ts
@@ -23,7 +23,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
 
   // Math.ceil guarantees that the colums will never get wider than the specified pixel width
   get cols(): number {
-    return Math.ceil(this.hostRef.nativeElement.clientWidth / 370);
+    return Math.ceil(this.hostRef.nativeElement.clientWidth / 450);
   }
   get limit(): number {
     return this.cols * 5;

--- a/hosting/src/app/shared/cards/image-card/image-card.component.scss
+++ b/hosting/src/app/shared/cards/image-card/image-card.component.scss
@@ -6,7 +6,7 @@
   justify-content: center;
 
   .mat-card {
-    height: calc(100% - 36px);
+    // height: calc(100% - 36px);
     width: calc(100% - 36px);
     display: flex;
     flex-direction: column;

--- a/hosting/src/app/state/articles/actions/article.actions.ts
+++ b/hosting/src/app/state/articles/actions/article.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { AppArticle, AppImage } from '@utils/interfaces';
+import { AppArticle } from '@utils/interfaces';
 
 export enum ArticleActionTypes {
   LoadSingleArticle = '[Article] Load Article',
@@ -13,7 +13,7 @@ export class LoadSingleArticle implements Action {
 }
 export class LoadSingleArticleSuccess implements Action {
   readonly type = ArticleActionTypes.LoadSingleArticleSuccess;
-  constructor(public payload: { article: AppArticle; image: AppImage }) {}
+  constructor(public payload: { article: AppArticle; imageUrl: string }) {}
 }
 export class LoadSingleArticleFailure implements Action {
   readonly type = ArticleActionTypes.LoadSingleArticleFailure;

--- a/hosting/src/app/state/articles/reducers/article.reducer.ts
+++ b/hosting/src/app/state/articles/reducers/article.reducer.ts
@@ -1,5 +1,5 @@
 import { ArticleActions, ArticleActionTypes } from '../actions/article.actions';
-import { AppArticle, AppImage } from '@utils/interfaces';
+import { AppArticle } from '@utils/interfaces';
 
 import * as fromRoot from '@state/state.module';
 
@@ -7,7 +7,7 @@ export const articleFeatureKey = 'article';
 
 export interface ArticleState {
   article: AppArticle;
-  image: AppImage;
+  imageUrl: string;
   isLoading: boolean;
 }
 
@@ -17,7 +17,7 @@ export interface State extends fromRoot.State {
 
 export const initialState: ArticleState = {
   article: null,
-  image: null,
+  imageUrl: '',
   isLoading: false,
 };
 
@@ -27,7 +27,7 @@ export function reducer(state = initialState, action: ArticleActions): ArticleSt
       return { ...state, isLoading: true };
 
     case ArticleActionTypes.LoadSingleArticleSuccess:
-      return { ...state, isLoading: false, article: action.payload.article, image: action.payload.image };
+      return { ...state, isLoading: false, article: action.payload.article, imageUrl: action.payload.imageUrl };
 
     case ArticleActionTypes.LoadSingleArticleFailure:
       return { ...state, isLoading: false };

--- a/hosting/src/app/state/groups/actions/content.actions.ts
+++ b/hosting/src/app/state/groups/actions/content.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { AppArticle, AppImage } from '@utils/interfaces';
+import { AppArticle } from '@utils/interfaces';
 
 export enum ContentActionTypes {
   LoadContent = '[common group component] Load Content',
@@ -25,7 +25,7 @@ export class LoadArtcileFailure implements Action {
 
 export class LoadImageSuccess implements Action {
   readonly type = ContentActionTypes.LoadImageSuccess;
-  constructor(public payload: { image: AppImage }) {}
+  constructor(public payload: { imageUrl: string }) {}
 }
 
 export class LoadImageFailure implements Action {

--- a/hosting/src/app/state/groups/reducers/content.reducer.ts
+++ b/hosting/src/app/state/groups/reducers/content.reducer.ts
@@ -6,7 +6,7 @@ export const contentFeatureKey = 'group';
 
 interface GroupState {
   article: AppArticle;
-  image: AppImage;
+  imageUrl: string;
 }
 
 export interface State extends fromRoot.State {
@@ -15,7 +15,7 @@ export interface State extends fromRoot.State {
 
 export const initialState: GroupState = {
   article: null,
-  image: null,
+  imageUrl: '',
 };
 
 export function reducer(state = initialState, action: ContentActions): GroupState {
@@ -24,7 +24,7 @@ export function reducer(state = initialState, action: ContentActions): GroupStat
       return { ...state, article: action.payload.article || null };
 
     case ContentActionTypes.LoadImageSuccess:
-      return { ...state, image: action.payload.image || null };
+      return { ...state, imageUrl: action.payload.imageUrl || '' };
 
     case ContentActionTypes.LoadContent:
       return initialState;


### PR DESCRIPTION
By directly changing how images are displayed in articles and and cards some sizing issues are fixes:

- fixes #280 
- fixes #285 

The now fixed article detail view way of adding an image to an articles should also be used to fix #224 and remove the duplication there. It also creates the ability to open the image in the browser without extra embedding, may fix #281.